### PR TITLE
Numpy deprecated code in Regularization task

### DIFF
--- a/tasks/5 Regularization/task-5-2-regularization/reg_utils.py
+++ b/tasks/5 Regularization/task-5-2-regularization/reg_utils.py
@@ -200,7 +200,7 @@ def predict(X, y, parameters):
     """
     
     m = X.shape[1]
-    p = np.zeros((1,m), dtype = np.int)
+    p = np.zeros((1,m), dtype = np.int64)
     
     # Forward propagation
     a3, caches = forward_propagation(X, parameters)


### PR DESCRIPTION
np.int throws an error in recent numpy versions, including the one installed in Google Colab. The fix is updating it to np.int64